### PR TITLE
Allows to filter out remote resources from preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You can control this plugin behavior with the following `udata.cfg` parameters:
 
 - **`TABULAR_CSVAPI_URL`**: The URL to your `csvapi` instance (without trailing slash). **ex:** `https://my.csvapi'
 - **`TABULAR_UI`**:  Choose the UI displaying previews. You can choose between `csvapi-front` and `dataexplorer'. Default value is `csvapi-front`
+- **`TABULAR_ALLOW_REMOTE`**: Whether or not to allow remote resources preview. Default value is `True`
 
 
 ## Development

--- a/udata_tabular_preview/preview.py
+++ b/udata_tabular_preview/preview.py
@@ -20,7 +20,13 @@ class TabularPreview(PreviewPlugin):
         return current_app.config.get('TABULAR_CSVAPI_URL')
 
     def can_preview(self, resource):
-        return bool(self.server_url) and resource.mime in SUPPORTED_MIME_TYPES
+        has_config = bool(self.server_url)
+        is_supported = resource.mime in SUPPORTED_MIME_TYPES
+        is_remote = resource.filetype == 'remote'
+        allow_remote = current_app.config.get('TABULAR_ALLOW_REMOTE')
+        is_allowed = allow_remote or not is_remote
+
+        return has_config and is_supported and is_allowed
 
     def preview_url(self, resource):
         return url_for('tabular.preview', url=resource.url)

--- a/udata_tabular_preview/preview.py
+++ b/udata_tabular_preview/preview.py
@@ -13,6 +13,8 @@ SUPPORTED_MIME_TYPES = (
 
 
 class TabularPreview(PreviewPlugin):
+    fallback = True
+
     @property
     def server_url(self):
         return current_app.config.get('TABULAR_CSVAPI_URL')

--- a/udata_tabular_preview/settings.py
+++ b/udata_tabular_preview/settings.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+'''
+Default settings for udata-tabular-preview
+'''
+# csvapi instance URL
+TABULAR_CSVAPI_URL = None
+
+# Preview UI, one of 'csvapi-front', 'data
+TABULAR_UI = 'csvapi-front'
+
+# Whether or not to allow remote resources
+TABULAR_ALLOW_REMOTE = True

--- a/udata_tabular_preview/views.py
+++ b/udata_tabular_preview/views.py
@@ -7,6 +7,8 @@ from flask import abort, current_app, render_template, Blueprint
 
 from udata import assets
 
+from . import settings as DEFAULTS
+
 blueprint = Blueprint('tabular', __name__, url_prefix='/tabular',
                       template_folder='templates',
                       static_folder='static')
@@ -29,7 +31,8 @@ def preview():
 
 @blueprint.record
 def init_preview(state):
-    state.app.config.setdefault('TABULAR_UI', 'csvapi-front')
+    for key, default in DEFAULTS.__dict__.items():
+        state.app.config.setdefault(key, default)
     with state.app.app_context():
         for key, manifest in MANIFESTS.items():
             assets.register_manifest(key, filename=manifest)


### PR DESCRIPTION
This PR adds a `TABULAR_ALLOW_REMOTE` parameter (which defaults to `True`) allowing to disable preview on remote resources.