### PR TITLE
Expose page size configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You can control this plugin behavior with the following `udata.cfg` parameters:
 - **`TABULAR_UI`**:  Choose the UI displaying previews. You can choose between `csvapi-front` and `dataexplorer'. Default value is `csvapi-front`
 - **`TABULAR_ALLOW_REMOTE`**: Whether or not to allow remote resources preview. Default value is `True`
 - **`TABULAR_MAX_SIZE`**: Max allowed file size in bytes if defined. Default value is `None`
+- **`TABULAR_PAGE_SIZE`**: fetched data page size. Default to `50`
 
 
 ## Development

--- a/udata_tabular_preview/settings.py
+++ b/udata_tabular_preview/settings.py
@@ -14,3 +14,6 @@ TABULAR_ALLOW_REMOTE = True
 
 # Max (included) allowed file size in bytes
 TABULAR_MAX_SIZE = None
+
+# Default page size
+TABULAR_PAGE_SIZE = 50

--- a/udata_tabular_preview/templates/tabular/preview.html
+++ b/udata_tabular_preview/templates/tabular/preview.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
     <meta name="csvapi-url" content="{{ config.TABULAR_CSVAPI_URL }}" />
+    <meta name="page-size" content="{{ config.TABULAR_PAGE_SIZE }}" />
     {% if config.TABULAR_UI == 'dataexplorer' %}
     <link href="{{ tabular_manifest('dataexplorer', 'main.css') }}" rel="stylesheet" >
     <link href="{{ tabular_manifest('dataexplorer', 'main.css') }}" rel="stylesheet"-->


### PR DESCRIPTION
Expose a `TABULAR_PAGE_SIZE` setting.

Connects to opendatateam/csvapi-front#1