### PR TITLE
Use extras to enable preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Use extras attributes to enable preview [#8](https://github.com/opendatateam/udata-tabular-preview/pull/8)
 
 ## 2.0.0 (2020-03-11)
 

--- a/tests/test_tabular_preview_preview.py
+++ b/tests/test_tabular_preview_preview.py
@@ -89,6 +89,22 @@ def test_display_preview_with_max_size(size):
 
 @pytest.mark.options(TABULAR_CSVAPI_URL='http://preview.me/',
                      TABULAR_MAX_SIZE=MAX_SIZE)
+def test_display_preview_using_extras():
+    extras = {
+        'check:headers:content-type': MIME_TYPE,
+        'check:headers:content-length': MAX_SIZE - 1,
+    }
+    resource = ResourceFactory(
+        mime=None,
+        filesize=None,
+        extras=extras
+    )
+
+    assert resource.preview_url == expected_url(resource.url)
+
+
+@pytest.mark.options(TABULAR_CSVAPI_URL='http://preview.me/',
+                     TABULAR_MAX_SIZE=MAX_SIZE)
 def test_no_preview_for_resource_over_max_size():
     resource = ResourceFactory(mime=MIME_TYPE, filesize=MAX_SIZE + 1)
 

--- a/udata_tabular_preview/preview.py
+++ b/udata_tabular_preview/preview.py
@@ -18,12 +18,23 @@ class TabularPreview(PreviewPlugin):
 
     def can_preview(self, resource):
         has_config = bool(self.server_url)
-        is_supported = resource.mime in SUPPORTED_MIME_TYPES
+
+        extras_mime = resource.extras.get('check:headers:content-type')
+        is_supported = (
+            extras_mime in SUPPORTED_MIME_TYPES
+            or resource.mime in SUPPORTED_MIME_TYPES
+        )
+
         is_remote = resource.filetype == 'remote'
         allow_remote = current_app.config.get('TABULAR_ALLOW_REMOTE')
         is_allowed = allow_remote or not is_remote
+
         max_size = current_app.config.get('TABULAR_MAX_SIZE')
-        size_ok = not max_size or (resource.filesize or float('inf')) <= max_size
+        extras_size = resource.extras.get('check:headers:content-length')
+        size_ok = (
+            not max_size
+            or (extras_size or resource.filesize or float("inf")) <= max_size
+        )
 
         return all((has_config, is_supported, is_allowed, size_ok))
 


### PR DESCRIPTION
Follow up of https://github.com/opendatateam/udata-croquemort/pull/133 to use extras on resources to enable tabular preview if the right MIME is set and filesize is compatible.

## TODO
- [ ] release udata-croquemort
- [ ] release tabular-preview after merging this