### PR TITLE
Specify version in static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Specify version in static [#27](https://github.com/opendatateam/udata-tabular-preview/pull/27)
 
 ## 3.0.2 (2023-03-02)
 

--- a/udata_tabular_preview/views.py
+++ b/udata_tabular_preview/views.py
@@ -1,8 +1,11 @@
+from time import time
+
 from flask import current_app, render_template, Blueprint
 
 from udata import assets
 from udata.frontend import template_hook
 
+from udata_tabular_preview import __version__
 from udata_tabular_preview.explore import can_explore
 
 from . import settings as DEFAULTS
@@ -54,5 +57,11 @@ def tabular_static(ui, filename):
     '''
     Get an UI asset path
     '''
-    static_root = assets.cdn_for('tabular.static', filename=ui, _external=True)
-    return f"{static_root}/{filename}"
+    url = assets.cdn_for('tabular.static', filename=ui + '/' + filename, _external=True)
+    if url.endswith('/'):  # this is a directory, no need for cache burst
+        return url
+    if current_app.config['DEBUG']:
+        burst = time()
+    else:
+        burst = __version__
+    return f"{url}?_={burst}"


### PR DESCRIPTION
We want to prevent using cached previous versions.

Inspired from https://github.com/etalab/udata-front/blob/d06489c4b3d1aa4a23ef3522fba503c3b086f374/udata_front/theme/__init__.py#L33.
In this case, I guess using `udata_tabular_preview.__version__` is the correct version to use?