### PR TITLE
Use either of analysis or header check mime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Use either of analysis or header check mime [#32](https://github.com/opendatateam/udata-tabular-preview/pull/32)
 
 ## 3.0.4 (2024-01-09)
 

--- a/tests/test_tabular_preview_preview.py
+++ b/tests/test_tabular_preview_preview.py
@@ -127,6 +127,23 @@ def test_display_preview_using_analysis_extras():
 @pytest.mark.options(TABULAR_EXPLORE_URL='http://preview.me',
                      TABULAR_CSVAPI_URL='http://csvapi.me/',
                      TABULAR_MAX_SIZE=MAX_SIZE)
+def test_display_preview_using_check_and_analysis_extras():
+    extras = {
+        'check:headers:content-type': MIME_TYPE,
+        'analysis:mime-type': 'incorrect/mime',
+        'analysis:content-length': MAX_SIZE - 1,
+    }
+    resource = ResourceFactory(
+        mime=None,
+        filesize=None,
+        extras=extras
+    )
+
+    assert resource.preview_url == expected_url(resource.latest)
+
+@pytest.mark.options(TABULAR_EXPLORE_URL='http://preview.me',
+                     TABULAR_CSVAPI_URL='http://csvapi.me/',
+                     TABULAR_MAX_SIZE=MAX_SIZE)
 def test_no_preview_for_resource_over_max_size():
     resource = ResourceFactory(mime=MIME_TYPE, filesize=MAX_SIZE + 1)
 

--- a/udata_tabular_preview/preview.py
+++ b/udata_tabular_preview/preview.py
@@ -17,10 +17,11 @@ class TabularPreview(PreviewPlugin):
         )
 
         supported_mimes = current_app.config.get('TABULAR_SUPPORTED_MIME_TYPES')
-        extras_mime = resource.extras.get('analysis:mime-type') \
-            or resource.extras.get('check:headers:content-type')
+        extras_analysis_mime = resource.extras.get('analysis:mime-type')
+        extras_headers_mime = resource.extras.get('check:headers:content-type')
         is_supported = (
-            extras_mime in supported_mimes
+            extras_analysis_mime in supported_mimes
+            or extras_headers_mime in supported_mimes
             or resource.mime in supported_mimes
         )
 


### PR DESCRIPTION
Analysis mime could be `text/plain`, while header is explicitly `text/csv`.
We would rather use any of those detected mime types that are supported.