### PR TITLE
Can't preview if parsing has failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Migrate to Python 3.11 following `udata` dependencies upgrade [#35](https://github.com/opendatateam/udata-tabular-preview/pull/35)
+- Don't show preview if parsing has failed [#36](https://github.com/opendatateam/udata-tabular-preview/pull/36)
 
 ## 4.0.0 (2024-03-22)
 

--- a/tests/test_tabular_preview_preview.py
+++ b/tests/test_tabular_preview_preview.py
@@ -57,3 +57,15 @@ def test_display_preview_without_max_size():
     resource = ResourceFactory(extras=DUMMY_EXTRAS, filesize=2 * MAX_SIZE)
 
     assert resource.preview_url == expected_url(resource.id)
+
+
+@pytest.mark.options(TABULAR_EXPLORE_URL='http://preview.me',
+                     TABULAR_API_URL='http://tabular-api.me/')
+def test_no_preview_if_parsing_failed():
+    extras = {
+        **DUMMY_EXTRAS,
+        "analysis:parsing:error": "csv_detective:sentry:xxx"
+    }
+    resource = ResourceFactory(extras=extras, filesize=2 * MAX_SIZE)
+
+    assert resource.preview_url is None

--- a/udata_tabular_preview/preview.py
+++ b/udata_tabular_preview/preview.py
@@ -15,8 +15,10 @@ class TabularPreview(PreviewPlugin):
             and bool(self.preview_base_url)
         )
 
-        is_hydra_table = resource.extras.get('analysis:parsing:finished_at') is not None
-
+        is_hydra_table = (
+            resource.extras.get('analysis:parsing:finished_at') is not None
+            and resource.extras.get('analysis:parsing:error') is None
+        )
         is_remote = resource.filetype == 'remote'
         allow_remote = current_app.config.get('TABULAR_ALLOW_REMOTE')
         is_allowed = allow_remote or not is_remote


### PR DESCRIPTION
We don't want to show the preview if we have an `analysis:parsing:error`