### PR TITLE
Set long description content type to markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Migrate to Python 3.11 following `udata` dependencies upgrade [#35](https://github.com/opendatateam/udata-tabular-preview/pull/35)
 - Don't show preview if parsing has failed [#36](https://github.com/opendatateam/udata-tabular-preview/pull/36)
 - Display the latest date of the preview [#37](https://github.com/opendatateam/udata-tabular-preview/pull/37)
+-  Set long description content type to markdown in dist [#39](https://github.com/opendatateam/udata-tabular-preview/pull/39)
 
 ## 4.0.0 (2024-03-22)
 

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     version=__import__('udata_tabular_preview').__version__,
     description=__import__('udata_tabular_preview').__description__,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/opendatateam/udata-tabular-preview',
     author='Open Data Team',
     author_email='contact@opendata.team',


### PR DESCRIPTION
As in other udata plugins, we want to specify the content type of long description (readme + changelog) as markdown.

Without it, the dist validation fails. Steps to reproduce :
```
inv dist
twine check dist/*
```