### PR TITLE
Improve explore button logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Remove useless max size setting [#41](https://github.com/opendatateam/udata-tabular-preview/pull/41)
+- Improve explore button logic [#43](https://github.com/opendatateam/udata-tabular-preview/pull/43)
 
 ## 4.0.0 (2024-05-06)
 
@@ -11,7 +12,7 @@
 - Don't show preview if parsing has failed [#36](https://github.com/opendatateam/udata-tabular-preview/pull/36)
 - Display the latest date of the preview [#37](https://github.com/opendatateam/udata-tabular-preview/pull/37)
 - Set long description content type to markdown in dist [#39](https://github.com/opendatateam/udata-tabular-preview/pull/39)
-- Publish .dev version on pypi [#40](https://github.com/opendatateam/udata-tabular-preview/pull/40) 
+- Publish .dev version on pypi [#40](https://github.com/opendatateam/udata-tabular-preview/pull/40)
 
 ## 4.0.0 (2024-03-22)
 

--- a/udata_tabular_preview/views.py
+++ b/udata_tabular_preview/views.py
@@ -21,6 +21,9 @@ def can_explore_dataset(ctx):
     dataset = ctx.get('dataset', None)
     return dataset and any(can_explore(resource) for resource in dataset.resources)
 
+def can_explore_any_main_resource(ctx):
+    dataset = ctx.get('dataset', None)
+    return any(can_explore(resource) and resource.type == "main" for resource in dataset.resources)
 
 @template_hook('header.snippets', when=can_explore_dataset)
 def load_explore_metadata(ctx):
@@ -42,7 +45,7 @@ def load_explore_style(ctx):
     return render_template('styles.html')
 
 
-@template_hook('dataset.display.explore-button', when=can_explore_dataset)
+@template_hook('dataset.display.explore-button', when=can_explore_any_main_resource)
 def load_explore_button(ctx):
     dataset = ctx.get('dataset', None)
     explore_url = current_app.config.get('TABULAR_EXPLORE_URL')

--- a/udata_tabular_preview/views.py
+++ b/udata_tabular_preview/views.py
@@ -24,7 +24,7 @@ def can_explore_dataset(ctx):
 
 def can_explore_any_main_resource(ctx):
     dataset = ctx.get('dataset', None)
-    return any(can_explore(resource) and resource.type == "main" for resource in dataset.resources)
+    return dataset and any(can_explore(resource) and resource.type == "main" for resource in dataset.resources)
 
 
 @template_hook('header.snippets', when=can_explore_dataset)

--- a/udata_tabular_preview/views.py
+++ b/udata_tabular_preview/views.py
@@ -21,9 +21,11 @@ def can_explore_dataset(ctx):
     dataset = ctx.get('dataset', None)
     return dataset and any(can_explore(resource) for resource in dataset.resources)
 
+
 def can_explore_any_main_resource(ctx):
     dataset = ctx.get('dataset', None)
     return any(can_explore(resource) and resource.type == "main" for resource in dataset.resources)
+
 
 @template_hook('header.snippets', when=can_explore_dataset)
 def load_explore_metadata(ctx):

--- a/udata_tabular_preview/views.py
+++ b/udata_tabular_preview/views.py
@@ -24,7 +24,10 @@ def can_explore_dataset(ctx):
 
 def can_explore_any_main_resource(ctx):
     dataset = ctx.get('dataset', None)
-    return dataset and any(can_explore(resource) and resource.type == "main" for resource in dataset.resources)
+    return dataset and any(
+        can_explore(resource)
+        and resource.type == "main"
+        for resource in dataset.resources)
 
 
 @template_hook('header.snippets', when=can_explore_dataset)


### PR DESCRIPTION
Fixes https://github.com/datagouv/data.gouv.fr/issues/1341

Don't show explore button on top of dataset page if there is no main resource explorable